### PR TITLE
More generic use of Coordinate Systems

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -621,8 +621,6 @@ dictionary XRRenderStateOptions {
 // Frame, Device Pose, and Views
 //
 
-// XRFrame and XRPose are also listed in spatial-tracking-explainer.md
-
 [SecureContext, Exposed=Window] interface XRFrame {
   readonly attribute XRSession session;
 
@@ -633,9 +631,11 @@ dictionary XRRenderStateOptions {
 
 [SecureContext, Exposed=Window]
 interface XRPose {
-  // TODO: Need for some flags here?
-  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute boolean emulatedPosition;
+  // TODO: Need for additional flags here?
+
   readonly attribute XRRigidTransform transform;
+  // TODO: Room for things like velocity and acceleration in the future
 };
 
 enum XREye {

--- a/explainer.md
+++ b/explainer.md
@@ -621,12 +621,21 @@ dictionary XRRenderStateOptions {
 // Frame, Device Pose, and Views
 //
 
+// XRFrame and XRPose are also listed in spatial-tracking-explainer.md
+
 [SecureContext, Exposed=Window] interface XRFrame {
   readonly attribute XRSession session;
 
   // Also listed in the spatial-tracking-explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
+  XRPose? getPose(XRSpace space, XRSpace relativeTo);
+};
+
+[SecureContext, Exposed=Window]
+interface XRPose {
+  // TODO: Need for some flags here?
+  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute XRRigidTransform transform;
 };
 
 enum XREye {
@@ -649,8 +658,7 @@ interface XRRigidTransform {
   readonly attribute XRRigidTransform transform;
 };
 
-[SecureContext, Exposed=Window] interface XRViewerPose {
-  readonly attribute XRRigidTransform transform;
+[SecureContext, Exposed=Window] interface XRViewerPose : XRPose {
   readonly attribute FrozenArray<XRView> views;
 };
 

--- a/explainer.md
+++ b/explainer.md
@@ -631,11 +631,8 @@ dictionary XRRenderStateOptions {
 
 [SecureContext, Exposed=Window]
 interface XRPose {
-  readonly attribute boolean emulatedPosition;
-  // TODO: Need for additional flags here?
-
   readonly attribute XRRigidTransform transform;
-  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute boolean emulatedPosition;
 };
 
 enum XREye {

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -25,15 +25,17 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 ### Input poses
 
-Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRReferenceSpace` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
+Each input source provides two `XRSpace`s, which can be used to query an `XRPose` using the `getPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRSpace` you want the pose for, as well as the `XRSpace` the returned pose should be relative to (which may be an `XRReferenceSpace`). Just like `getViewerPose()`, `getPose()` may return `null` in cases where tracking has been lost, or the `XRSpace`'s `XRInputSource` instance is no longer connected or available.
 
-The `gripTransform` is an `XRRigidTransform` into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
+The `gripSpace` represents a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-If the input source has only 3DOF, the `gripTransform` may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripTransform` will be `null` if the input source isn't trackable. 
+If the input source has only 3DOF, the grip pose may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripSpace` will be `null` if the input source isn't trackable. 
 
-An input source will also provide its preferred pointing ray, given by the `XRInputPose`'s `targetRay`. The ray, which is an `XRRay` object, includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. A matrix can also be queried from the `XRRay` with the `matrix` attribute which represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
+An input source will also provide its preferred pointing ray, given by the `XRInputSource`'s `targetRaySpace`. This can be used to get the input's target ray `XRPose`.
 
-The `targetRay` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
+An `XRRay` can be constructed from the `XRPose`'s `transform`. Rays includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. The `XRRay`'s `matrix` represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
+
+The `targetCoordinateSystem` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetMode` attribute:
 
   * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a `gripTransform`), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'tracked-pointer'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
@@ -42,16 +44,16 @@ The `targetRay` will never be `null`. It's value will differ based on the type o
 ```js
 // Loop over every input source and get their pose for the current frame.
 for (let inputSource of xrInputSources) {
-  let inputPose = xrFrame.getInputPose(inputSource, xrReferenceSpace);
+  let targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, xrReferenceSpace);
 
   // Check to see if the pose is valid
-  if (inputPose) {
+  if (targetRayPose) {
     // Render a visualization of the input source (see next section).
-    renderInputSource(session, inputSource, inputPose);
+    let gripPose = xrFrame.getPose(inputSource.gripCoordinateSystem, xrFrameOfRef);
+    renderInputSource(session, inputSource, gripPose);
 
     // Highlight any objects that the target ray intersects with.
-    let ray = inputPose.targetRay;
-    let hoveredObject = scene.getObjectIntersectingRay(ray.origin, ray.direction);
+    let hoveredObject = scene.getObjectIntersectingRay(new XRRay(targetRayPose.transform));
     if (hoveredObject) {
       // Render a visualization of the object that is highlighted (see below).
       drawHighlightFrom(hoveredObject, inputSource);
@@ -72,7 +74,7 @@ function onSessionStarted(session) {
     lastInputSource = event.inputSource;
   });
   session.addEventListener("inputsourceschange", ev => {
-    // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetRayMode:
+    // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetMode:
     // 'screen' over 'tracked-pointer' over 'gaze'.
     lastInputSource = computePreferredInputSource(session.getInputSources());
   });
@@ -92,10 +94,10 @@ function drawHighlightFrom(hoveredObject, inputSource) {
 function drawScene() {
   // Display only a single cursor or ray, on the most recently used input source.
   if (lastInputSource) {
-    let inputPose = xrFrame.getInputPose(lastInputSource, xrReferenceSpace);
-    if (inputPose) {
+    let targetRayPose = xrFrame.getPose(lastInputSource.targetRaySpace, xrReferenceSpace);
+    if (targetRayPose) {
       // Render a visualization of the target ray/cursor of the active input source. (see next section)
-      renderCursor(lastInputSource, inputPose)
+      renderCursor(lastInputSource, targetRayPose)
     }
   }
 }
@@ -134,11 +136,10 @@ function onSessionStarted(session) {
 }
 
 function onSelect(event) {
-  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
-  if (inputPose) {
+  let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace, xrReferenceSpace);
+  if (targetRayPose) {
     // Ray cast into scene to determine if anything was hit.
-    let ray = inputPose.targetRay;
-    let selectedObject = scene.getObjectIntersectingRay(ray.origin, ray.direction);
+    let selectedObject = scene.getObjectIntersectingRay(new XRRay(targetRayPose.transform));
     if (selectedObject) {
       selectedObject.onSelect();
     }
@@ -146,7 +147,7 @@ function onSelect(event) {
 }
 ```
 
-Some input sources (such as those with a `targetRayMode` of `screen`) will be only be added to the list of input sources whilst a primary action is occurring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
+Some input sources (such as those with a `targetMode` of `screen`) will be only be added to the list of input sources whilst a primary action is occurring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
 
 `selectstart` and `selectend` can be useful for handling dragging, painting, or other continuous motions.
 
@@ -170,40 +171,38 @@ function onSelect(event) {
 
 ### Rendering input sources
 
-Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
+Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetMode` attribute:
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'tracked-pointer'`: If the `gripTransform` is not `null` an application-appropriate controller model should be drawn using that transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
+  * `'tracked-pointer'`: If the `gripSpace` is not `null` an application-appropriate controller model should be drawn using that pose. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
   * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
 // These methods presumes the use of a fictionalized rendering library.
 
 // Render a visualization of the input source - eg. a controller mesh.
-function renderInputSource(session, inputSource, inputPose) {
+function renderInputSource(session, inputSource, gripPose) {
   // FIXME: Using a fictional isDisplayOpaque() method to state that controller meshes should not be rendered
   // on transparent displays (AR).
-  if (isDisplayOpaque(session) && inputPose.gripTransform) {
-    // Render a controller mesh the using the gripTransform.
+  if (isDisplayOpaque(session) && gripPose) {
+    // Render a controller mesh if the using the gripPose as a transform.
     let controllerMesh = getControllerMesh(inputSource);
-    renderer.drawMeshAtTransform(controllerMesh, inputPose.gripTransform);
+    renderer.drawMeshAtTransform(controllerMesh, gripPose.transform);
   }
 }
 
 // Render a visualization of target ray of the input source - eg. a line or cursor.
 // Presumes the use of a fictionalized rendering library.
-function renderCursor(inputSource, inputPose) {
+function renderCursor(inputSource, targetPose) {
   // Only render a target ray if this was the most recently used input source.
-  if (inputSource.targetRayMode == "tracked-pointer") {
+  if (inputSource.targetMode == "tracked-pointer") {
     // Draw targeting rays for tracked-pointer devices only.
-    let ray = inputPose.targetRay;
-    renderer.drawRay(ray.origin, ray.direction);
+    renderer.drawRay(new XRRay(targetPose.transform));
   }
 
-  if (inputSource.targetRayMode != 'screen') {
+  if (inputSource.targetMode != 'screen') {
     // Draw a cursor for gazing and tracked-pointer devices only.
-    let ray = inputPose.targetRay;
-    let cursorPosition = scene.getIntersectionPoint(ray.origin, ray.direction);
+    let cursorPosition = scene.getIntersectionPoint(new XRRay(targetPose.transform));
     if (cursorPosition) {
       renderer.drawCursor(cursorPosition);
     }
@@ -231,21 +230,24 @@ function onSelectStart(event) {
   if (activeDragInteraction)
     return;
   
-  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   // Ignore the event if this input source is not capable of tracking.
-  if (!inputPose || !inputPose.gripTransform)
+  if (!event.inputSource.gripSpace)
+    return;
+
+  let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace, xrReferenceSpace);
+  let gripPose = event.frame.getPose(event.inputSource.gripSpace, xrReferenceSpace);
+  if (!targetRayPose || !gripPose)
     return;
 
   // Use the input source target ray to find a draggable object in the scene
-  let ray = inputPose.targetRay;
-  let hitResult = scene.hitTest(ray.origin, ray.direction);
+  let hitResult = scene.hitTest(new XRRay(targetRayPose.transform));
   if (hitResult && hitResult.draggable) {
-    // Use the grip position to drag the intersected object, rather than the target ray.
+    // Use the gripPose position to drag the intersected object, rather than the target ray.
     activeDragInteraction = {
       target: hitResult,
       targetStartPosition: hitResult.position,
       inputSource: event.inputSource,
-      inputSourceStartPosition: inputPose.gripTransform.position;
+      inputSourceStartPosition: gripPose.transform.position;
     };
   }
 }
@@ -259,11 +261,11 @@ function onSelectEnd(event) {
 // Called by the fictional app/middleware every frame
 function onUpdateScene() {
   if (activeDragInteraction) {
-    let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrReferenceSpace);
-    if (inputPose && inputPose.gripTransform) {
+    let gripPose = frame.getPose(activeDragInteraction.inputSource.gripSpace, xrReferenceSpaces);
+    if (!gripPose) {
       // Determine the vector from the start of the drag to the input source's current position
       // and position the draggable object accordingly
-      let deltaPosition = Vector3.subtract(inputPose.gripTransform.position, activeDragInteraction.inputSourceStartPosition);
+      let deltaPosition = Vector3.subtract(gripPose.transform.position, activeDragInteraction.inputSourceStartPosition);
       let newPosition = Vector3.add(activeDragInteraction.targetStartPosition, deltaPosition);
       activeDragInteraction.target.setPosition(newPosition);
     }
@@ -271,13 +273,13 @@ function onUpdateScene() {
 }
 ```
 
-The above sample is optimized for dragging items in the scene around using input sources that have a `gripTransform`. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
+The above sample is optimized for dragging items in the scene around using input sources that have a `gripSpace`. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
 
 ### Screen Input
 
 When using an inline session or an immersive AR session on a 2D screen, pointer events on the canvas that created the session's `outputContext` are monitored. `XRInputSource`s are generated in response to allow unified input handling with immersive mode controller or gaze input.
 
-When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetRayMode` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
+When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetMode` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
 
 For each of these events the `XRInputSource`'s target ray must be updated to originate at the point that was interacted with on the canvas, projected onto the near clipping plane (defined by the `depthNear` attribute of the `XRSession`) and extending out into the scene along that projected vector.
 
@@ -295,15 +297,6 @@ partial interface XRSession {
   attribute EventHandler onselectstart;
   attribute EventHandler onselectend;
   attribute EventHandler oninputsourceschange;
-};
-
-//
-// Frame
-//
-
-partial interface XRFrame {
-  // Also listed in the spatial-tracking-explainer.md
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 //
@@ -335,13 +328,8 @@ enum XRTargetRayMode {
 interface XRInputSource {
   readonly attribute XRHandedness handedness;
   readonly attribute XRTargetRayMode targetRayMode;
-};
-
-[SecureContext, Exposed=Window]
-interface XRInputPose {
-  readonly attribute boolean emulatedPosition;
-  readonly attribute XRRay targetRay;
-  readonly attribute XRRigidTransform? gripTransform;
+  readonly attribute XRSpace targetRaysSpace;
+  readonly attribute XRSpace? gripSpace;
 };
 
 //

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -48,13 +48,6 @@ for (let inputSource of xrInputSources) {
 
   // Check to see if the pose is valid
   if (targetRayPose) {
-    if (inputSource.gripSpace) {
-      // Render a visualization of the input source if it has a grip space.
-      // (See next section for details).
-      let gripPose = xrFrame.getPose(inputSource.gripSpace, xrFrameOfRef);
-      renderInputSource(session, inputSource, gripPose);
-    }
-
     // Highlight any objects that the target ray intersects with.
     let hoveredObject = scene.getObjectIntersectingRay(new XRRay(targetRayPose.transform));
     if (hoveredObject) {
@@ -62,6 +55,10 @@ for (let inputSource of xrInputSources) {
       drawHighlightFrom(hoveredObject, inputSource);
     }
   }
+
+  // Render a visualization of the input source if appropriate.
+  // (See next section for details).
+  renderInputSource(xrFrame, inputSource);
 }
 ```
 
@@ -184,11 +181,17 @@ Most applications will want to visually represent the input sources somehow. The
 // These methods presumes the use of a fictionalized rendering library.
 
 // Render a visualization of the input source - eg. a controller mesh.
-function renderInputSource(session, inputSource, gripPose) {
+function renderInputSource(xrFrame, inputSource) {
+  // Don't render an input source if it doesn't have a grip space.
+  if (!inputSource.gripSpace)
+    return;
+
+  let gripPose = xrFrame.getPose(inputSource.gripSpace, xrFrameOfRef);
+
   // Controller meshes should not be rendered on transparent displays (AR), so
   // only render a controller mesh if the XREnvironmentBlendMode is 'opaque' and
   // we have a valid gripPose to transform it with.
-  if (gripPose && session.environmentBlendMode == 'opaque') {
+  if (gripPose && xrFrame.session.environmentBlendMode == 'opaque') {
     let controllerMesh = getControllerMesh(inputSource);
     renderer.drawMeshAtTransform(controllerMesh, gripPose.transform);
   }

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -25,17 +25,15 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 ### Input poses
 
-Each input source provides two `XRSpace`s, which can be used to query an `XRPose` using the `getPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRSpace` you want the pose for, as well as the `XRSpace` the returned pose should be relative to (which may be an `XRReferenceSpace`). Just like `getViewerPose()`, `getPose()` may return `null` in cases where tracking has been lost, or the `XRSpace`'s `XRInputSource` instance is no longer connected or available.
+Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRReferenceSpace` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
 
-The `gripSpace` represents a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
+The `gripTransform` is an `XRRigidTransform` into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-If the input source has only 3DOF, the grip pose may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripSpace` will be `null` if the input source isn't trackable. 
+If the input source has only 3DOF, the `gripTransform` may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripTransform` will be `null` if the input source isn't trackable. 
 
-An input source will also provide its preferred pointing ray, given by the `XRInputSource`'s `targetRaySpace`. This can be used to get the input's target ray `XRPose`.
+An input source will also provide its preferred pointing ray, given by the `XRInputPose`'s `targetRay`. The ray, which is an `XRRay` object, includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. A matrix can also be queried from the `XRRay` with the `matrix` attribute which represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
 
-An `XRRay` can be constructed from the `XRPose`'s `transform`. Rays includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. The `XRRay`'s `matrix` represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
-
-The `targetCoordinateSystem` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetMode` attribute:
+The `targetRay` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
   * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a `gripTransform`), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'tracked-pointer'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
@@ -44,16 +42,16 @@ The `targetCoordinateSystem` will never be `null`. It's value will differ based 
 ```js
 // Loop over every input source and get their pose for the current frame.
 for (let inputSource of xrInputSources) {
-  let targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, xrReferenceSpace);
+  let inputPose = xrFrame.getInputPose(inputSource, xrReferenceSpace);
 
   // Check to see if the pose is valid
-  if (targetRayPose) {
+  if (inputPose) {
     // Render a visualization of the input source (see next section).
-    let gripPose = xrFrame.getPose(inputSource.gripCoordinateSystem, xrFrameOfRef);
-    renderInputSource(session, inputSource, gripPose);
+    renderInputSource(session, inputSource, inputPose);
 
     // Highlight any objects that the target ray intersects with.
-    let hoveredObject = scene.getObjectIntersectingRay(new XRRay(targetRayPose.transform));
+    let ray = inputPose.targetRay;
+    let hoveredObject = scene.getObjectIntersectingRay(ray.origin, ray.direction);
     if (hoveredObject) {
       // Render a visualization of the object that is highlighted (see below).
       drawHighlightFrom(hoveredObject, inputSource);
@@ -74,7 +72,7 @@ function onSessionStarted(session) {
     lastInputSource = event.inputSource;
   });
   session.addEventListener("inputsourceschange", ev => {
-    // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetMode:
+    // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetRayMode:
     // 'screen' over 'tracked-pointer' over 'gaze'.
     lastInputSource = computePreferredInputSource(session.getInputSources());
   });
@@ -94,10 +92,10 @@ function drawHighlightFrom(hoveredObject, inputSource) {
 function drawScene() {
   // Display only a single cursor or ray, on the most recently used input source.
   if (lastInputSource) {
-    let targetRayPose = xrFrame.getPose(lastInputSource.targetRaySpace, xrReferenceSpace);
-    if (targetRayPose) {
+    let inputPose = xrFrame.getInputPose(lastInputSource, xrReferenceSpace);
+    if (inputPose) {
       // Render a visualization of the target ray/cursor of the active input source. (see next section)
-      renderCursor(lastInputSource, targetRayPose)
+      renderCursor(lastInputSource, inputPose)
     }
   }
 }
@@ -136,10 +134,11 @@ function onSessionStarted(session) {
 }
 
 function onSelect(event) {
-  let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace, xrReferenceSpace);
-  if (targetRayPose) {
+  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
+  if (inputPose) {
     // Ray cast into scene to determine if anything was hit.
-    let selectedObject = scene.getObjectIntersectingRay(new XRRay(targetRayPose.transform));
+    let ray = inputPose.targetRay;
+    let selectedObject = scene.getObjectIntersectingRay(ray.origin, ray.direction);
     if (selectedObject) {
       selectedObject.onSelect();
     }
@@ -147,7 +146,7 @@ function onSelect(event) {
 }
 ```
 
-Some input sources (such as those with a `targetMode` of `screen`) will be only be added to the list of input sources whilst a primary action is occurring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
+Some input sources (such as those with a `targetRayMode` of `screen`) will be only be added to the list of input sources whilst a primary action is occurring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
 
 `selectstart` and `selectend` can be useful for handling dragging, painting, or other continuous motions.
 
@@ -171,38 +170,40 @@ function onSelect(event) {
 
 ### Rendering input sources
 
-Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetMode` attribute:
+Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'tracked-pointer'`: If the `gripSpace` is not `null` an application-appropriate controller model should be drawn using that pose. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
+  * `'tracked-pointer'`: If the `gripTransform` is not `null` an application-appropriate controller model should be drawn using that transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
   * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
 // These methods presumes the use of a fictionalized rendering library.
 
 // Render a visualization of the input source - eg. a controller mesh.
-function renderInputSource(session, inputSource, gripPose) {
+function renderInputSource(session, inputSource, inputPose) {
   // FIXME: Using a fictional isDisplayOpaque() method to state that controller meshes should not be rendered
   // on transparent displays (AR).
-  if (isDisplayOpaque(session) && gripPose) {
-    // Render a controller mesh if the using the gripPose as a transform.
+  if (isDisplayOpaque(session) && inputPose.gripTransform) {
+    // Render a controller mesh the using the gripTransform.
     let controllerMesh = getControllerMesh(inputSource);
-    renderer.drawMeshAtTransform(controllerMesh, gripPose.transform);
+    renderer.drawMeshAtTransform(controllerMesh, inputPose.gripTransform);
   }
 }
 
 // Render a visualization of target ray of the input source - eg. a line or cursor.
 // Presumes the use of a fictionalized rendering library.
-function renderCursor(inputSource, targetPose) {
+function renderCursor(inputSource, inputPose) {
   // Only render a target ray if this was the most recently used input source.
-  if (inputSource.targetMode == "tracked-pointer") {
+  if (inputSource.targetRayMode == "tracked-pointer") {
     // Draw targeting rays for tracked-pointer devices only.
-    renderer.drawRay(new XRRay(targetPose.transform));
+    let ray = inputPose.targetRay;
+    renderer.drawRay(ray.origin, ray.direction);
   }
 
-  if (inputSource.targetMode != 'screen') {
+  if (inputSource.targetRayMode != 'screen') {
     // Draw a cursor for gazing and tracked-pointer devices only.
-    let cursorPosition = scene.getIntersectionPoint(new XRRay(targetPose.transform));
+    let ray = inputPose.targetRay;
+    let cursorPosition = scene.getIntersectionPoint(ray.origin, ray.direction);
     if (cursorPosition) {
       renderer.drawCursor(cursorPosition);
     }
@@ -230,24 +231,21 @@ function onSelectStart(event) {
   if (activeDragInteraction)
     return;
   
+  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   // Ignore the event if this input source is not capable of tracking.
-  if (!event.inputSource.gripSpace)
-    return;
-
-  let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace, xrReferenceSpace);
-  let gripPose = event.frame.getPose(event.inputSource.gripSpace, xrReferenceSpace);
-  if (!targetRayPose || !gripPose)
+  if (!inputPose || !inputPose.gripTransform)
     return;
 
   // Use the input source target ray to find a draggable object in the scene
-  let hitResult = scene.hitTest(new XRRay(targetRayPose.transform));
+  let ray = inputPose.targetRay;
+  let hitResult = scene.hitTest(ray.origin, ray.direction);
   if (hitResult && hitResult.draggable) {
-    // Use the gripPose position to drag the intersected object, rather than the target ray.
+    // Use the grip position to drag the intersected object, rather than the target ray.
     activeDragInteraction = {
       target: hitResult,
       targetStartPosition: hitResult.position,
       inputSource: event.inputSource,
-      inputSourceStartPosition: gripPose.transform.position;
+      inputSourceStartPosition: inputPose.gripTransform.position;
     };
   }
 }
@@ -261,11 +259,11 @@ function onSelectEnd(event) {
 // Called by the fictional app/middleware every frame
 function onUpdateScene() {
   if (activeDragInteraction) {
-    let gripPose = frame.getPose(activeDragInteraction.inputSource.gripSpace, xrReferenceSpaces);
-    if (!gripPose) {
+    let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrReferenceSpace);
+    if (inputPose && inputPose.gripTransform) {
       // Determine the vector from the start of the drag to the input source's current position
       // and position the draggable object accordingly
-      let deltaPosition = Vector3.subtract(gripPose.transform.position, activeDragInteraction.inputSourceStartPosition);
+      let deltaPosition = Vector3.subtract(inputPose.gripTransform.position, activeDragInteraction.inputSourceStartPosition);
       let newPosition = Vector3.add(activeDragInteraction.targetStartPosition, deltaPosition);
       activeDragInteraction.target.setPosition(newPosition);
     }
@@ -273,13 +271,13 @@ function onUpdateScene() {
 }
 ```
 
-The above sample is optimized for dragging items in the scene around using input sources that have a `gripSpace`. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
+The above sample is optimized for dragging items in the scene around using input sources that have a `gripTransform`. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
 
 ### Screen Input
 
 When using an inline session or an immersive AR session on a 2D screen, pointer events on the canvas that created the session's `outputContext` are monitored. `XRInputSource`s are generated in response to allow unified input handling with immersive mode controller or gaze input.
 
-When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetMode` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
+When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetRayMode` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
 
 For each of these events the `XRInputSource`'s target ray must be updated to originate at the point that was interacted with on the canvas, projected onto the near clipping plane (defined by the `depthNear` attribute of the `XRSession`) and extending out into the scene along that projected vector.
 
@@ -297,6 +295,15 @@ partial interface XRSession {
   attribute EventHandler onselectstart;
   attribute EventHandler onselectend;
   attribute EventHandler oninputsourceschange;
+};
+
+//
+// Frame
+//
+
+partial interface XRFrame {
+  // Also listed in the spatial-tracking-explainer.md
+  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 //
@@ -325,11 +332,15 @@ enum XRTargetRayMode {
 };
 
 [SecureContext, Exposed=Window]
-interface XRInputSource {
+interface XRInputSource : XRSpace {
   readonly attribute XRHandedness handedness;
   readonly attribute XRTargetRayMode targetRayMode;
-  readonly attribute XRSpace targetRaysSpace;
-  readonly attribute XRSpace? gripSpace;
+};
+
+[SecureContext, Exposed=Window]
+interface XRInputPose : XRPose {
+  readonly attribute XRRay targetRay; // Ray version of the pose transform?
+  readonly attribute XRRigidTransform? gripTransform;
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -354,11 +354,8 @@ partial interface XRFrame {
 
 [SecureContext, Exposed=Window]
 interface XRPose {
-  readonly attribute boolean emulatedPosition;
-  // TODO: Need for additional flags here?
-
   readonly attribute XRRigidTransform transform;
-  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute boolean emulatedPosition;
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -350,9 +350,6 @@ partial interface XRFrame {
   // Also listed in the main explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
   XRPose? getPose(XRSpace space, XRSpace relativeTo);
-
-  // Also listed in input-explainer.md	
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 [SecureContext, Exposed=Window]
@@ -369,7 +366,7 @@ interface XRPose {
 //
 
 [SecureContext, Exposed=Window] interface XRSpace : EventTarget {
-  // TODO: Anything meaningful we can put here?
+  // Intentionally an opaque type, used by XRInputSource.
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -255,7 +255,7 @@ There are several circumstances in which developers may choose to relate content
 It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`. In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `transform` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and set it as the `originOffset` of the `immersive` session's `XRReferenceSpace`. The same logic applies in the reverse when exiting `immersive`.
 
 #### Unbounded to Bounded 
-When building an experience that is predominantly based on an `XRUnboundedReferenceSpace`, developers may occasionally choose to switch to an `XRBoundedReferenceSpace`.  For example, a whole-home renovation experience might choose to switch to a bounded reference space for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous reference space, developers may use the `getTransformTo()` method to re-parent nearby virtual content to the new reference space.
+When building an experience that is predominantly based on an `XRUnboundedReferenceSpace`, developers may occasionally choose to switch to an `XRBoundedReferenceSpace`.  For example, a whole-home renovation experience might choose to switch to a bounded reference space for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous reference space, developers may call the `XRFrame`'s `getPose()` method to re-parent nearby virtual content to the new reference space.
 
 ### Reset Event
 The `XRReferenceSpace` type has an event, `onreset`, that is fired when a discontinuity of the reference space's origin occurs.  This discontinuity may be caused for different reasons for each type, but the result is essentially the same, the perception of the user's location will have changed.  In response, pages may wish to reposition virtual elements in the scene or clear any additional transforms, such as teleportation transforms, that may no longer be needed.  The `onreset` event will fire prior to any poses being delivered with the new origin/direction, and all poses queried following the event must be relative to the reset origin/direction. 
@@ -349,16 +349,14 @@ partial interface XRSession {
 partial interface XRFrame {
   // Also listed in the main explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
-
-  // Also listed in input-explainer.md
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
+  XRPose? getPose(XRSpace space, XRSpace relativeTo);
 };
 
 [SecureContext, Exposed=Window]
-interface XRInputPose {
-  readonly attribute boolean emulatedPosition;
-  readonly attribute XRRay targetRay;
-  readonly attribute XRRigidTransform? gripTransform;
+interface XRPose {
+  // TODO: Need for some flags here?
+  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute XRRigidTransform transform;
 };
 
 //
@@ -366,7 +364,7 @@ interface XRInputPose {
 //
 
 [SecureContext, Exposed=Window] interface XRSpace : EventTarget {
-  XRRigidTransform? getTransformTo(XRSpace other);
+  // TODO: Anything meaningful we can put here?
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -350,13 +350,18 @@ partial interface XRFrame {
   // Also listed in the main explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
   XRPose? getPose(XRSpace space, XRSpace relativeTo);
+
+  // Also listed in input-explainer.md	
+  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 [SecureContext, Exposed=Window]
 interface XRPose {
-  // TODO: Need for some flags here?
-  // TODO: Room for things like velocity and acceleration in the future
+  readonly attribute boolean emulatedPosition;
+  // TODO: Need for additional flags here?
+
   readonly attribute XRRigidTransform transform;
+  // TODO: Room for things like velocity and acceleration in the future
 };
 
 //


### PR DESCRIPTION
A few different things have gotten my thinking about how to make the concept of "tracking stuff" in WebXR more generic/extensible. Some examples:

- Verbiage weirdness when talking about querying viewers/views
- The conversation about the body locked frame of reference and how it felt like an unfortunate one-off
- Reviewing some input concepts
- Thinking about Anchors
- Thinking about Hit testing reticles
- Name bikeshedding
- Not wanting to have the number of ways we exposed tracked objects explode (because it IS a core part of the API)
- How we integrate better with various native libraries

So the idea that came out of all of that that I wanted to feel out is simply pushing `XRCoordinateSystem` to a more visible, central place in the API (which probably further justifies the spatial systems bikeshedding, FWIW). Basically making it so that ANYTHING that is tracked spatially is represented as a coordinate system and all of them use a single function to get it's spatial state. (Querying the views array is still a special case because it needs to be.) Some highlights:

 - XRFrame is two functions: `getViewer()` for the views array and `getPose()` for all coordinate systems.
 - Input devices are represented as two coordinate systems: target and grip.
 - The grip coordinate system being nullable nicely allows us to communicate "I don't have a grip pose" vs "I don't have a grip pose _right now_"
 - You can construct an `XRRay` from any `XRPose`. Useful for things like forcing gaze cursors in all cases.

This WIP patch is more focused on IDL and sample code changes than explainer text changes at the moment, but I don't want to invest a lot of time into the text until I've sanity checked it with you. It builds off of a prior but not yet merged PR I've got up on the main repo because the changes it introduced nicely support this change.