### PR TITLE
Anchors and hit testing

### DIFF
--- a/input-explainer.md
+++ b/input-explainer.md
@@ -295,10 +295,6 @@ function onSessionStarted(session) {
   // Rest of session start up logic
 }
 
-
-  session.addEventListener("inputsourceschange", ev => {
-  });
-
 let preferredHitTestSource = null;
 function onInputSourcesChange(event) {
   let oldPreferredInputSource = preferredInputSource;

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -395,25 +395,49 @@ interface XRRay {
   readonly attribute Float32Array matrix;
 };
 
+[SecureContext, Exposed=Window]
+interface XRInputSource {
+  readonly attribute XRSpace targetRaySpace;
+  readonly attribute XRHitTestSource hitTestSource;
+};
+
 enum XRHandedness {
   "",
   "left",
   "right"
 };
 
-enum XRTargetRayMode {
-  "gaze",
-  "tracked-pointer",
-  "screen"
+[SecureContext, Exposed=Window]
+interface XRTrackedInputSource : XRInputSource {
+  readonly attribute XRHandedness handedness;
+  readonly attribute XRSpace gripSpace;
+
+  // From the other PR
+  readonly attribute XRTrackedController? controller;
+  readonly attribute DOMString renderId;
 };
 
+// Per our conversation, I'm contemplating the approach that one of these should
+// ALWAYS be present with gamepad=null.  One and only one.  Regardless of whether 
+// or not there's other input sources.  It's a tad bit weird if there's a gamepad
+// plugged in, but I think it's less confusing to have two XRViewerInputSource
+// objects (one with gamepad and one without) to ensure that the oninputsourcechange 
+// event behaves as expected should the gamepad be unplugged.
+//
+// The bonus to this approach is that in the event handler for select, developers can
+// query the button on the gamepad that actually fired the event...
+//
+// Also your point about tracked controllers potentially having both hands and buttons
+// can also  be applied to the XRViewerInputSource if needed.
 [SecureContext, Exposed=Window]
-interface XRInputSource {
-  readonly attribute XRHandedness handedness;
-  readonly attribute XRTargetRayMode targetRayMode;
-  readonly attribute XRSpace targetRaySpace;
-  readonly attribute XRSpace? gripSpace;
-  readonly attribute XRHitTestSource hitTestSource;
+interface XRViewerInputSource : XRInputSource {
+  readonly attribute Gamepad? gamepad;
+};
+
+// One per touch-point
+[SecureContext, Exposed=Window]
+interface XRScreenInputSource : XRInputSource {
+  // Add screen coordinates?
 };
 
 //

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -390,7 +390,7 @@ This is a partial IDL and is considered additive to the core IDL found in the ma
 //
 
 partial interface XRSession {
-  Promise<XRHitTestSource> requestHitTestSource(XRSpace space, optional XRRay ray, optional XRHitTestType hitTestType);
+  Promise<XRHitTestSource> requestHitTestSource(XRSpace space, optional XRRay ray, optional XRSpaceType spaceType);
 
   FrozenArray<XRInputSource> getInputSources();
   
@@ -467,6 +467,9 @@ interface XRScreenInputSource : XRInputSource {
 // Hit Testing
 //
 
+// TODO: Fix this AWFUL name.  I don't want to imply spaces can only be of this list
+// I just was looking for something that would be usable by anchors too...
+// Maybe I should just call it XRAnchorType even though it'll be passed into requestHitTestSource?
 enum XRSpaceType {
   "",
   "vertical-plane",
@@ -477,7 +480,7 @@ enum XRSpaceType {
 dictionary XRHitTestSourceOptions {
   required XRSpace space;
   attribute XRRay offsetRay = new XRRay();
-  XRHitTestType type = ""; 
+  XRSpaceType type = ""; 
 };
 
 // TODO: Consider if this should inherit from XRSpace instead?
@@ -485,11 +488,11 @@ dictionary XRHitTestSourceOptions {
 interface XRHitTestSource {
   readonly attribute XRSpace space;
   readonly attribute XRRay offsetRay;
-  readonly attribute XRHitTestType type; 
+  readonly attribute XRSpaceType type; 
 
   // TODO: Probably shouldn't add these, but I don't want to lose track of the possible approach
   // Promise<void> updateOffsetRay(XRRay ray);
-  // Promise<void> updateType(XRHitTestType type);
+  // Promise<void> updateType(XRSpaceType type);
 };
 
 [SecureContext, Exposed=Window]
@@ -498,7 +501,7 @@ interface XRHitTestResult {
   readonly attribute XRRay normal;
 
   // if we go the "type" approach, we probably want these here:
-  readonly attribute XRHitTestType type;
+  readonly attribute XRSpaceType type;
   readonly attribute FrozenArray<DOMPointReadOnly>? boundsGeometry;
 
   // TODO: Consider other things like:

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -359,7 +359,7 @@ partial interface XRFrame {
   // Also listed in the main explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
   XRPose? getPose(XRSpace space, XRSpace relativeTo);
-  Promise<XRAnchor> requestAnchor(XRSpace relativeTo, XRRigidTransform offset);
+  Promise<XRAnchor> requestAnchor(XRAnchorOptions options);
 };
 
 [SecureContext, Exposed=Window]
@@ -436,8 +436,15 @@ interface XRUnboundedReferenceSpace : XRReferenceSpace {
 // Anchor
 //
 
+dictionary XRAnchorOptions  {
+  required XRSpace relativeTo;
+  XRRigidTransform offset;
+  XRSpaceType type;
+};
+
 [SecureContext, Exposed=Window] 
 interface XRAnchor : XRSpace {
+  readonly attribute XRSpaceType type;
   // Is this meaningful? Or can we get rid of this type altogether for right now?
   attribute EventHandler onupdate;
 };

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -284,6 +284,15 @@ Example reasons `onreset` may fire:
 
 The `onreset` event will **NOT** fire as an `XRUnboundedReferenceSpace` makes small changes to its origin as part of maintaining space stability near the user; these are considered minor corrections rather than a discontinuity in the origin.
 
+## Anchors
+```js
+  let hitTestResults = xrFrame.getHitTestResults(hitTestSource, xrReferenceSpace);
+  let xrAnchor = null;
+  xrFrame.requestAnchor(xrReferenceSpace, hitTestResults[0].transform).then((anchor) => {
+    xrAnchor = anchor;
+  });
+```
+
 ## Appendix A : Miscellaneous
 
 ### Tracking Systems Overview
@@ -350,6 +359,7 @@ partial interface XRFrame {
   // Also listed in the main explainer.md
   XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
   XRPose? getPose(XRSpace space, XRSpace relativeTo);
+  Promise<XRAnchor> requestAnchor(XRSpace relativeTo, XRRigidTransform offset);
 };
 
 [SecureContext, Exposed=Window]
@@ -420,6 +430,16 @@ interface XRBoundedReferenceSpace : XRReferenceSpace {
 
 [SecureContext, Exposed=Window] 
 interface XRUnboundedReferenceSpace : XRReferenceSpace {
+};
+
+//
+// Anchor
+//
+
+[SecureContext, Exposed=Window] 
+interface XRAnchor : XRSpace {
+  // Is this meaningful? Or can we get rid of this type altogether for right now?
+  attribute EventHandler onupdate;
 };
 
 //


### PR DESCRIPTION
Really early thinking about how to bring in hit-testing and anchors on top of the pose refactor we just completed.  As I mentioned earlier, I really think the whole input explainer needs to be cleaned up because concepts are scattered around the document.
Also, because I based this branch on the PR in the webxr repo, when you review the changes, make sure you're only looking at the commits I added on top.