### PR TITLE
[Editorial] Status metadata does not need "w3c/"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Shortname: webxr
 Title: WebXR Device API
 Group: immersivewebwg
-Status: w3c/ED
+Status: ED
 TR: https://www.w3.org/TR/webxr/
 ED: https://immersive-web.github.io/webxr/
 Repository: immersive-web/webxr


### PR DESCRIPTION
Status metadata for bikeshed does not require "w3c/". This will also fix missing banner at top left for editors' draft.